### PR TITLE
Make Distortion vector to be pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,7 +498,7 @@ impl<R: RealField> RosOpenCvIntrinsics<R> {
 /// Specifies distortion using the Brown-Conrady "plumb bob" model.
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde-serialize", derive(Serialize, Deserialize))]
-pub struct Distortion<R: RealField>(Vector5<R>);
+pub struct Distortion<R: RealField>(pub Vector5<R>);
 
 impl<R: RealField> Distortion<R> {
     /// build from vector ordered [radial1, radial2, tangential1, tangential2, radial3]


### PR DESCRIPTION
I found no way to access the vector inside the `Distortion`. I make it pub to be easily converted to actual OpenCV library.

If you wonder it loses the _semantics_ of the type, perhaps we can add a `opencv_vector()` method instead.